### PR TITLE
pino: add a hook to record logging metrics

### DIFF
--- a/packages/pino-log-enricher/lib/createFormatter.js
+++ b/packages/pino-log-enricher/lib/createFormatter.js
@@ -42,13 +42,19 @@ module.exports = function createFormatter(newrelic) {
     },
     hooks: {
       logMethod(inputArgs, method, level) {
-        // We'll try to use level labels for the metric name, but if
-        // they don't exist, we'll default back to the level number.
-        const levelLabel = this.levels.labels[level] || level
-        newrelic.shim.agent.metrics.getOrCreateMetric('Logging/lines').incrementCallCount()
-        newrelic.shim.agent.metrics
-          .getOrCreateMetric(`Logging/lines/${levelLabel}`)
-          .incrementCallCount()
+        const config = newrelic.shim.agent.config
+
+        // TODO: update the peerdep on the New Relic repo and thereby
+        // remove check for existence of application_logging config item
+        if (config.application_logging && config.application_logging.metrics.enabled) {
+          // We'll try to use level labels for the metric name, but if
+          // they don't exist, we'll default back to the level number.
+          const levelLabel = this.levels.labels[level] || level
+          newrelic.shim.agent.metrics.getOrCreateMetric('Logging/lines').incrementCallCount()
+          newrelic.shim.agent.metrics
+            .getOrCreateMetric(`Logging/lines/${levelLabel}`)
+            .incrementCallCount()
+        }
         return method.apply(this, inputArgs)
       }
     }

--- a/packages/pino-log-enricher/lib/createFormatter.js
+++ b/packages/pino-log-enricher/lib/createFormatter.js
@@ -39,6 +39,18 @@ module.exports = function createFormatter(newrelic) {
         }
         return obj
       }
+    },
+    hooks: {
+      logMethod(inputArgs, method, level) {
+        // We'll try to use level labels for the metric name, but if
+        // they don't exist, we'll default back to the level number.
+        const levelLabel = this.levels.labels[level] || level
+        newrelic.shim.agent.metrics.getOrCreateMetric('Logging/lines').incrementCallCount()
+        newrelic.shim.agent.metrics
+          .getOrCreateMetric(`Logging/lines/${levelLabel}`)
+          .incrementCallCount()
+        return method.apply(this, inputArgs)
+      }
     }
   }
 }

--- a/packages/pino-log-enricher/tests/versioned/pino.tap.js
+++ b/packages/pino-log-enricher/tests/versioned/pino.tap.js
@@ -96,4 +96,36 @@ tap.test('Pino instrumentation', (t) => {
     t.notOk(line['entity.type'])
     t.end()
   })
+
+  t.test('should count logger metrics', (t) => {
+    helper.runInTransaction('pino-test', async () => {
+      const logLevels = {
+        debug: 20,
+        info: 5,
+        warn: 3,
+        error: 2
+      }
+      for (const [logLevel, maxCount] of Object.entries(logLevels)) {
+        for (let count = 0; count < maxCount; count++) {
+          const msg = `This is log message #${count} at ${logLevel} level`
+          logger[logLevel](msg)
+        }
+      }
+      await once(stream, 'data')
+
+      let grandTotal = 0
+      for (const [logLevel, maxCount] of Object.entries(logLevels)) {
+        grandTotal += maxCount
+        const metricName = `Logging/lines/${logLevel}`
+        const metric = helper.agent.metrics.getMetric(metricName)
+        t.ok(metric, `ensure ${metricName} exists`)
+        t.equal(metric.callCount, maxCount, `ensure ${metricName} has the right value`)
+      }
+      const metricName = `Logging/lines`
+      const metric = helper.agent.metrics.getMetric(metricName)
+      t.ok(metric, `ensure ${metricName} exists`)
+      t.equal(metric.callCount, grandTotal, `ensure ${metricName} has the right value`)
+      t.end()
+    })
+  })
 })

--- a/packages/pino-log-enricher/tests/versioned/pino.tap.js
+++ b/packages/pino-log-enricher/tests/versioned/pino.tap.js
@@ -31,6 +31,7 @@ tap.test('Pino instrumentation', (t) => {
   t.autoend()
   let logger
   let config
+  let pinoConfig
   let helper
   let stream
   let api
@@ -41,7 +42,9 @@ tap.test('Pino instrumentation', (t) => {
     pino = require('pino')
     api = new API(helper.agent)
     stream = sink()
-    logger = pino(formatFactory(api), stream)
+    pinoConfig = formatFactory(api)
+    pinoConfig.level = 'debug'
+    logger = pino(pinoConfig, stream)
     config = helper.agent.config
   })
 

--- a/packages/pino-log-enricher/tests/versioned/pino.tap.js
+++ b/packages/pino-log-enricher/tests/versioned/pino.tap.js
@@ -39,6 +39,7 @@ tap.test('Pino instrumentation', (t) => {
 
   t.beforeEach(() => {
     helper = utils.TestAgent.makeInstrumented()
+    helper.agent.config.application_logging = { metrics: { enabled: true } }
     pino = require('pino')
     api = new API(helper.agent)
     stream = sink()


### PR DESCRIPTION
Pino by default reports log numbers. Since we need the logging level
labels, that's only on the logger object. From the config provided by
the Pino API, only hooks seem to bring in the logger context, from
which we can try to reverse the log level number to its label.


## Proposed Release Notes

* Enable logging metrics for pino log enricher

## Links

* Closes #24 

## Details
