### PR TITLE
Replaces writing to dev null with a generic/cross-plat compatible stub

### DIFF
--- a/packages/winston-log-enricher/tests/versioned/winston.tap.js
+++ b/packages/winston-log-enricher/tests/versioned/winston.tap.js
@@ -5,7 +5,6 @@
 
 'use strict'
 
-const fs = require('fs')
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 const formatFactory = require('../../lib/createFormatter.js')
@@ -13,6 +12,7 @@ const concat = require('concat-stream')
 const API = require('newrelic/api')
 const StubApi = require('newrelic/stub_api')
 const winston = require('winston')
+const stream = require('stream')
 
 utils(tap)
 
@@ -446,7 +446,12 @@ tap.test('Winston instrumentation', (t) => {
 
   t.test('should count logger metrics', (t) => {
     helper.runInTransaction('winston-test)', () => {
-      const nullStream = fs.createWriteStream('/dev/null')
+      const nullStream = new stream.Writable({
+        write: (chunk, encoding, cb) => {
+          cb()
+        }
+      })
+
       const logger = winston.createLogger({
         transports: [
           new winston.transports.Stream({


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

For now, the stub just immediately invokes the callback since we aren't worried about async execution for speed. But if we needed async execution it should be invoked in a setImmediate(). The cost isn't that much so we could do that now, as well.
