### PR TITLE
added additional check for application_logging.enabled before sending metrics

### DIFF
--- a/packages/winston-log-enricher/lib/createFormatter.js
+++ b/packages/winston-log-enricher/lib/createFormatter.js
@@ -54,7 +54,11 @@ module.exports = function createFormatter(newrelic, winston) {
 
     // TODO: update the peerdep on the New Relic repo and thereby
     // remove check for existence of application_logging config item
-    if (config.application_logging && config.application_logging.metrics.enabled) {
+    if (
+      config.application_logging &&
+      config.application_logging.enabled &&
+      config.application_logging.metrics.enabled
+    ) {
       const levelLabel = info.level
       newrelic.shim.agent.metrics.getOrCreateMetric('Logging/lines').incrementCallCount()
       newrelic.shim.agent.metrics


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added check for `application_logging.enabled` before sending Logging metrics to collector endpoint.

## Links

## Details
I had an open question on the spec and the previous PR #37 was merged while I was out and before I could make a comment.  This fix should keep it aligned with application logging spec.
