### PR TITLE
added missing supportability metrics to align with the logging spec

### DIFF
--- a/packages/pino-log-enricher/lib/createFormatter.js
+++ b/packages/pino-log-enricher/lib/createFormatter.js
@@ -75,4 +75,5 @@ function createModuleUsageMetric(agent) {
   agent.metrics
     .getOrCreateMetric('Supportability/ExternalModules/PinoLogEnricher')
     .incrementCallCount()
+  agent.metrics.getOrCreateMetric('Supportability/Logging/Nodejs/pino/enabled').incrementCallCount()
 }

--- a/packages/winston-log-enricher/lib/createFormatter.js
+++ b/packages/winston-log-enricher/lib/createFormatter.js
@@ -73,4 +73,7 @@ function createModuleUsageMetric(agent) {
   agent.metrics
     .getOrCreateMetric('Supportability/ExternalModules/WinstonLogEnricher')
     .incrementCallCount()
+  agent.metrics
+    .getOrCreateMetric('Supportability/Logging/Nodejs/winston/enabled')
+    .incrementCallCount()
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added additional supportability metrics when the log enrichers are invoked.

## Links
Closes #42

## Details
This was yet another item in the spec that was misinterpreted.  The enabled flag was a must the disabled was a should(and out of scope for our agent).
