### PR TITLE
Release/winston enricher@3.0.0

### DIFF
--- a/packages/winston-log-enricher/CHANGELOG.md
+++ b/packages/winston-log-enricher/CHANGELOG.md
@@ -1,5 +1,41 @@
 # CHANGELOG
 
+## 3.0.0 (04/28/2022)
+
+**BREAKING**:  Updated the signature to require passing in the winston package instead of relying on it being a peer dependency.
+
+Before:
+
+```js
+const newrelicFormatter = require('@newrelic/winston-enricher')
+
+format: winston.format.combine(
+  winston.format.label({label: 'test'}),
+  newrelicFormatter()
+)
+```
+
+Now:
+
+```js
+const nrWinstonEnricher = require('@newrelic/winston-enricher')
+const newrelicFormatter = nrWinstonEnricher(winston)
+
+
+format: winston.format.combine(
+  winston.format.label({label: 'test'}),
+  newrelicFormatter()
+)
+```
+
+ * Added ability to report logs within transaction context to the agent when `config.application_logging.forwarding.enabled` is true.
+ * Added application logging user metrics when `config.application_logging.metrics.enabled` is true.(`Logging/lines` and `Logging/lines/<level>`).
+ * Added supportability metrics to indicate when log enricher is enabled.(`Supportability/Logging/Nodejs/winston/enabled`)
+ * Bumped tap to ^16.0.1.
+ * Fixed third-party notice generation.
+ * Bumped @newrelic/test-utilities ^6.5.3.
+ * Dev-only npm audit fixes.
+
 ## 2.1.1 (04/05/2022)
 
 * Made Winston a peer dependency.

--- a/packages/winston-log-enricher/package-lock.json
+++ b/packages/winston-log-enricher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/winston-enricher",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/winston-enricher",
-      "version": "2.1.2",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@newrelic/test-utilities": "^6.5.3",

--- a/packages/winston-log-enricher/package.json
+++ b/packages/winston-log-enricher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/winston-enricher",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "New Relic log enricher for the `winston` package. Allows `winston` logs to be consumed by New Relic Logs.",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
**BREAKING**:  Updated the signature to require passing in the winston package instead of relying on it being a peer dependency.

Before:

```js
const newrelicFormatter = require('@newrelic/winston-enricher')

format: winston.format.combine(
  winston.format.label({label: 'test'}),
  newrelicFormatter()
)
```

Now:

```js
const nrWinstonEnricher = require('@newrelic/winston-enricher')
const newrelicFormatter = nrWinstonEnricher(winston)


format: winston.format.combine(
  winston.format.label({label: 'test'}),
  newrelicFormatter()
)
```

 * Added ability to report logs within transaction context to the agent when `config.application_logging.forwarding.enabled` is true.
 * Added application logging user metrics when `config.application_logging.metrics.enabled` is true.(`Logging/lines` and `Logging/lines/<level>`).
 * Added supportability metrics to indicate when log enricher is enabled.(`Supportability/Logging/Nodejs/winston/enabled`)
 * Bumped tap to ^16.0.1.
 * Fixed third-party notice generation.
 * Bumped @newrelic/test-utilities ^6.5.3.
 * Dev-only npm audit fixes.


## Links
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/29
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/30/files
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/33
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/37
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/38/files
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/39/files
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/40/files
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/43/files
 