### PR TITLE
winston-log-enricher: add to log with or without transactions

### DIFF
--- a/packages/winston-log-enricher/lib/createFormatter.js
+++ b/packages/winston-log-enricher/lib/createFormatter.js
@@ -66,22 +66,16 @@ module.exports = function createFormatter(newrelic, winston) {
         .incrementCallCount()
     }
 
-    // Need three conditions to be true to send logs to the
-    // aggregator:
-    // 1) the aggregator exists
-    // 2) we are in a transaction
-    // 3) forwarding is enabled in the config
-    const segment = newrelic.shim.getActiveSegment()
-    const inTransaction = segment && segment.transaction
-
     const forwardingEnabled =
       config.application_logging &&
       config.application_logging.enabled &&
       config.application_logging.forwarding &&
       config.application_logging.forwarding.enabled
 
-    if (newrelic.agent.logs && inTransaction && forwardingEnabled) {
-      newrelic.agent.logs.add(info, segment.transaction.priority)
+    if (newrelic.agent.logs && forwardingEnabled) {
+      // The priority (null second argument) will be randomly set
+      // later, and it's okay if it doesn't match the transaction priority.
+      newrelic.agent.logs.add(info, null)
     }
 
     return jsonFormatter.transform(info, opts)

--- a/packages/winston-log-enricher/tests/versioned/winston.tap.js
+++ b/packages/winston-log-enricher/tests/versioned/winston.tap.js
@@ -138,7 +138,7 @@ tap.test('Winston instrumentation', (t) => {
             // back with transaction context, so let's construct the
             // message with that extra metadata for the assertion.
             const logAggregatorMsg = {
-              ...helper.agent.logs.add.args[0][0],
+              ...helper.agent.logs.add.args[1][0],
               ...metadata
             }
             t.same(
@@ -148,9 +148,11 @@ tap.test('Winston instrumentation', (t) => {
             )
           }
         })
-        // Only one winning combination: in transaction and with
-        // proper config
-        t.equal(helper.agent.logs.add.callCount, 1, 'should have only called log aggregator once')
+        t.equal(
+          helper.agent.logs.add.callCount,
+          2,
+          'should have only called log aggregator two times'
+        )
       })
     )
 


### PR DESCRIPTION
We misunderstood a sentence in the application logging spec for
agents. Logs can still be set outside of a transaction, and the
priority of a log doesn't have to be related to the priority of any
transaction.

## Links

Closes #46 