### PR TITLE
favor forwarding when forwarding and local decorating are both enabled

### DIFF
--- a/packages/winston-log-enricher/lib/createFormatter.js
+++ b/packages/winston-log-enricher/lib/createFormatter.js
@@ -45,13 +45,13 @@ module.exports = function createFormatter(newrelic, winston) {
       incrementLoggingLinesMetrics(info, newrelic)
     }
 
-    if (isLocalDecoratingEnabled(config)) {
-      const metadata = newrelic.getLinkingMetadata(true)
-      info.message += formatLinkingMetadata(metadata)
-    } else if (isLogFowardingEnabled(config, newrelic)) {
+    if (isLogFowardingEnabled(config, newrelic)) {
       const metadata = newrelic.getLinkingMetadata(true)
       reformatLogLine(info, metadata, newrelic)
       newrelic.agent.logs.add(info)
+    } else if (isLocalDecoratingEnabled(config)) {
+      const metadata = newrelic.getLinkingMetadata(true)
+      info.message += formatLinkingMetadata(metadata)
     } else if (isLogEnricher(config)) {
       const metadata = newrelic.getLinkingMetadata(true)
       reformatLogLine(info, metadata, newrelic)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated formatter to choose application log forwarding when both application log forwarding and application local log decorating are both enabled

## Links
Closes #53

## Details
The highlighted, desired use case will be forwarding our code should also reflect this.
