### PR TITLE
updated readme to explain new behavior of enricher with agent 8.11.0

### DIFF
--- a/packages/winston-log-enricher/README.md
+++ b/packages/winston-log-enricher/README.md
@@ -36,7 +36,7 @@ format: winston.format.combine(
 
 **Using log enricher with Node.js agent >= 8.11.0:**
 
-Node.js agent 8.11.0 introduced [application logging](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-nodejs/).  By default it will instrument winston automatically and depending on your application logging configuration, it may favor log decorating + in agent forwarding or local log decorating instead of log enrichment.  Log enrichment will still work without any configurations but it is recommended to add the following to your newrelic configuration:
+Node.js agent 8.11.0 introduced [application logging](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-nodejs/).  By default the agent will instrument winston automatically and depending on your application logging configuration, may favor in agent log forwarding with decoration or local log decorating instead of traditional log enrichment. Log enrichment will still work without any configurations but it is recommended to add the following to your newrelic configuration:
 
 ```js
   application_logging: {

--- a/packages/winston-log-enricher/README.md
+++ b/packages/winston-log-enricher/README.md
@@ -34,6 +34,16 @@ format: winston.format.combine(
 )
 ```
 
+**Using log enricher with Node.js agent >= 8.11.0:**
+
+Node.js agent 8.11.0 introduced [application logging](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-nodejs/).  By default it will instrument winston automatically and depending on your application logging configuration, it may favor log decorating + in agent forwarding or local log decorating instead of log enrichment.  Log enrichment will still work without any configurations but it is recommended to add the following to your newrelic configuration:
+
+```js
+  application_logging: {
+    enabled: false
+  }
+```
+
 **Note for unhandledException log messages:**
 
 The stack trace will be written to the `error.stack` property.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I felt like we needed some explanation/suggestion in the log enricher around disabling application logging.  The enricher will continue to work it's just behaving differently and just best to completely disable application logging if you have no intention of using the agent feature.
