### PR TITLE
pino-enricher: updated peer dep to be >= so customers can install agent 9.x which supports Node 18

### DIFF
--- a/packages/pino-log-enricher/THIRD_PARTY_NOTICES.md
+++ b/packages/pino-log-enricher/THIRD_PARTY_NOTICES.md
@@ -31,7 +31,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.2.0](https://github.com/newrelic/node-test-utilities/tree/v6.2.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.2.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.5.3](https://github.com/newrelic/node-test-utilities/tree/v6.5.3)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.5.3/LICENSE):
 
 ```
                                  Apache License

--- a/packages/pino-log-enricher/package.json
+++ b/packages/pino-log-enricher/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/newrelic/newrelic-node-log-extensions#readme",
   "peerDependencies": {
-    "newrelic": "^8.6.0"
+    "newrelic": ">=8.13.0"
   },
   "devDependencies": {
     "@newrelic/test-utilities": "^6.5.3",

--- a/packages/pino-log-enricher/third_party_manifest.json
+++ b/packages/pino-log-enricher/third_party_manifest.json
@@ -1,20 +1,20 @@
 {
-  "lastUpdated": "Wed Apr 20 2022 15:00:44 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Thu Oct 13 2022 13:42:12 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Pino Log Enricher",
   "projectUrl": "https://github.com/newrelic/newrelic-node-pino-logenricher",
   "includeOptDeps": false,
   "includeDev": true,
   "dependencies": {},
   "devDependencies": {
-    "@newrelic/test-utilities@6.2.0": {
+    "@newrelic/test-utilities@6.5.3": {
       "name": "@newrelic/test-utilities",
-      "version": "6.2.0",
-      "range": "^6.2.0",
+      "version": "6.5.3",
+      "range": "^6.5.3",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.2.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.5.3",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.2.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.5.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"

--- a/packages/winston-log-enricher/THIRD_PARTY_NOTICES.md
+++ b/packages/winston-log-enricher/THIRD_PARTY_NOTICES.md
@@ -32,7 +32,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-wins
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v5.1.0](https://github.com/newrelic/node-test-utilities/tree/v5.1.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v5.1.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.5.3](https://github.com/newrelic/node-test-utilities/tree/v6.5.3)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.5.3/LICENSE):
 
 ```
                                  Apache License
@@ -272,7 +272,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v8.7.1](https://github.com/newrelic/node-newrelic/tree/v8.7.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v8.7.1/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v8.12.0](https://github.com/newrelic/node-newrelic/tree/v8.12.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v8.12.0/LICENSE):
 
 ```
                                  Apache License
@@ -480,7 +480,7 @@ This product includes source derived from [newrelic](https://github.com/newrelic
 
 ### tap
 
-This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.0.1](https://github.com/tapjs/node-tap/tree/v16.0.1)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.0.1/LICENSE):
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.2.0](https://github.com/tapjs/node-tap/tree/v16.2.0)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.2.0/LICENSE):
 
 ```
 The ISC License
@@ -520,7 +520,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### winston
 
-This product includes source derived from [winston](https://github.com/winstonjs/winston) ([v3.6.0](https://github.com/winstonjs/winston/tree/v3.6.0)), distributed under the [MIT License](https://github.com/winstonjs/winston/blob/v3.6.0/LICENSE):
+This product includes source derived from [winston](https://github.com/winstonjs/winston) ([v3.7.2](https://github.com/winstonjs/winston/tree/v3.7.2)), distributed under the [MIT License](https://github.com/winstonjs/winston/blob/v3.7.2/LICENSE):
 
 ```
 Copyright (c) 2010 Charlie Robbins

--- a/packages/winston-log-enricher/third_party_manifest.json
+++ b/packages/winston-log-enricher/third_party_manifest.json
@@ -1,20 +1,20 @@
 {
-  "lastUpdated": "Wed Apr 20 2022 15:00:44 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Thu Oct 13 2022 13:42:12 GMT-0400 (Eastern Daylight Time)",
   "projectName": "@newrelic/winston-enricher",
   "projectUrl": "https://github.com/newrelic/newrelic-winston-logenricher-node",
   "includeOptDeps": false,
   "includeDev": true,
   "dependencies": {},
   "devDependencies": {
-    "@newrelic/test-utilities@5.1.0": {
+    "@newrelic/test-utilities@6.5.3": {
       "name": "@newrelic/test-utilities",
-      "version": "5.1.0",
-      "range": "^5.1.0",
+      "version": "6.5.3",
+      "range": "^6.5.3",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v5.1.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.5.3",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v5.1.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.5.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -32,28 +32,28 @@
       "publisher": "Max Ogden",
       "email": "max@maxogden.com"
     },
-    "newrelic@8.7.1": {
+    "newrelic@8.12.0": {
       "name": "newrelic",
-      "version": "8.7.1",
+      "version": "8.12.0",
       "range": "^8.7.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v8.7.1",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v8.12.0",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v8.7.1/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v8.12.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "tap@16.0.1": {
+    "tap@16.2.0": {
       "name": "tap",
-      "version": "16.0.1",
-      "range": "^16.0.1",
+      "version": "16.2.0",
+      "range": "^16.2.0",
       "licenses": "ISC",
       "repoUrl": "https://github.com/tapjs/node-tap",
-      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.0.1",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.2.0",
       "licenseFile": "node_modules/tap/LICENSE",
-      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.0.1/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.2.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",
@@ -73,15 +73,15 @@
       "email": "sam.verschueren@gmail.com",
       "url": "https://github.com/SamVerschueren"
     },
-    "winston@3.6.0": {
+    "winston@3.7.2": {
       "name": "winston",
-      "version": "3.6.0",
+      "version": "3.7.2",
       "range": "^3.6.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/winstonjs/winston",
-      "versionedRepoUrl": "https://github.com/winstonjs/winston/tree/v3.6.0",
+      "versionedRepoUrl": "https://github.com/winstonjs/winston/tree/v3.7.2",
       "licenseFile": "node_modules/winston/LICENSE",
-      "licenseUrl": "https://github.com/winstonjs/winston/blob/v3.6.0/LICENSE",
+      "licenseUrl": "https://github.com/winstonjs/winston/blob/v3.7.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Charlie Robbins",
       "email": "charlie.robbins@gmail.com"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Apr 20 2022 15:00:41 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Thu Oct 13 2022 13:42:10 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node.js Log Extensions",
   "projectUrl": "https://github.com/newrelic/newrelic-node-log-extensions",
   "includeOptDeps": false,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated pino-enricher to define agent peer dependency of `>=8.13.0` so you can install 9.x of agent to get Node.js 18 support.

## Links

## Details
This was discovered when the snyk bot PRd a fix to the [Dockerfile](https://github.com/newrelic/newrelic-node-examples/pull/18) to use Node.js 18.  I realized this wouldn't technically work as it would be installing a 8.x version of agent which does not support 18.
