### PR TITLE
@newrelic/pino-enricher@1.1.0

### DIFF
--- a/packages/pino-log-enricher/CHANGELOG.md
+++ b/packages/pino-log-enricher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.0 (10/17/2022)
+
+ * Updated pino-enricher to define agent peer dependency of >=8.13.0 so you can install 9.x of agent to get Node.js 18 support.
+
 ## 1.0.0 (07/27/2022)
 
 * **BREAKING** Removed support for Node 12.

--- a/packages/pino-log-enricher/package-lock.json
+++ b/packages/pino-log-enricher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/pino-enricher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/pino-enricher",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@newrelic/test-utilities": "^6.5.3",

--- a/packages/pino-log-enricher/package.json
+++ b/packages/pino-log-enricher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/pino-enricher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "New Relic log encricher for the `pino` package. Allows `pino` logs to be consumed by New Relic Logs.",
   "main": "index.js",
   "scripts": {

--- a/packages/pino-log-enricher/third_party_manifest.json
+++ b/packages/pino-log-enricher/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Oct 13 2022 13:42:12 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Oct 17 2022 13:35:45 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Pino Log Enricher",
   "projectUrl": "https://github.com/newrelic/newrelic-node-pino-logenricher",
   "includeOptDeps": false,

--- a/packages/winston-log-enricher/third_party_manifest.json
+++ b/packages/winston-log-enricher/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Oct 13 2022 13:42:12 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Oct 17 2022 13:35:45 GMT-0400 (Eastern Daylight Time)",
   "projectName": "@newrelic/winston-enricher",
   "projectUrl": "https://github.com/newrelic/newrelic-winston-logenricher-node",
   "includeOptDeps": false,

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Oct 13 2022 13:42:10 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Oct 17 2022 13:35:44 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node.js Log Extensions",
   "projectUrl": "https://github.com/newrelic/newrelic-node-log-extensions",
   "includeOptDeps": false,


### PR DESCRIPTION
## Proposed Release Notes
  * Updated pino-enricher to define agent peer dependency of >=8.13.0 so you can install 9.x of agent to get Node.js 18 support.

## Links
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/76
 * https://github.com/newrelic/newrelic-node-log-extensions/pull/78

## Details
