### PR TITLE
Fix: Truncate shouldn't throw on invalid input

### DIFF
--- a/packages/pino-log-enricher/lib/truncate.js
+++ b/packages/pino-log-enricher/lib/truncate.js
@@ -8,7 +8,7 @@
 const MAX_LENGTH = 1021
 const OUTPUT_LENGTH = 1024
 const truncate = (str) => {
-  if (str.length > OUTPUT_LENGTH) {
+  if (typeof str === 'string' && str.length > OUTPUT_LENGTH) {
     return str.substring(0, MAX_LENGTH) + '...'
   }
 

--- a/packages/pino-log-enricher/lib/truncate.js
+++ b/packages/pino-log-enricher/lib/truncate.js
@@ -5,8 +5,9 @@
 
 'use strict'
 
-const MAX_LENGTH = 1021
 const OUTPUT_LENGTH = 1024
+const MAX_LENGTH = 1021
+
 const truncate = (str) => {
   if (typeof str === 'string' && str.length > OUTPUT_LENGTH) {
     return str.substring(0, MAX_LENGTH) + '...'

--- a/packages/pino-log-enricher/tests/unit/messageTruncate.tap.js
+++ b/packages/pino-log-enricher/tests/unit/messageTruncate.tap.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const tap = require('tap')
-const trucate = require('../../lib/truncate')
+const truncate = require('../../lib/truncate')
 
 tap.test('Should truncate string > 1024 chars', (t) => {
   const longString =
@@ -29,7 +29,7 @@ tap.test('Should truncate string > 1024 chars', (t) => {
     '1111111111111111111111111111111111111111111111111111111111111111' +
     '1111111111111111111111111111111111111111111111111111111111111111'
 
-  const processedStr = trucate(longString)
+  const processedStr = truncate(longString)
 
   t.equal(processedStr.length, 1024)
   t.equal(processedStr.substring(processedStr.length - 3), '...')
@@ -40,8 +40,22 @@ tap.test('Should truncate string > 1024 chars', (t) => {
 tap.test('Should return non-truncated string when <= 1024 chars', (t) => {
   const str = 'kenny loggins'
 
-  const processedStr = trucate(str)
+  const processedStr = truncate(str)
 
   t.equal(processedStr, str)
   t.end()
+})
+;[
+  { value: '', type: 'empty string' },
+  { value: undefined, type: 'undefined' },
+  { value: null, type: 'null' },
+  { value: {}, type: 'object' },
+  { value: [], type: 'array' },
+  { value: function () {}, type: 'function' }
+].forEach(({ value, type }) => {
+  tap.test(`should not truncate ${type}`, (t) => {
+    const newValue = truncate(value)
+    t.same(value, newValue)
+    t.end()
+  })
 })

--- a/packages/winston-log-enricher/lib/truncate.js
+++ b/packages/winston-log-enricher/lib/truncate.js
@@ -8,7 +8,7 @@
 const MAX_LENGTH = 1021
 const OUTPUT_LENGTH = 1024
 const truncate = (str) => {
-  if (str.length > OUTPUT_LENGTH) {
+  if (typeof str === 'string' && str.length > OUTPUT_LENGTH) {
     return str.substring(0, MAX_LENGTH) + '...'
   }
 

--- a/packages/winston-log-enricher/lib/truncate.js
+++ b/packages/winston-log-enricher/lib/truncate.js
@@ -5,8 +5,9 @@
 
 'use strict'
 
-const MAX_LENGTH = 1021
 const OUTPUT_LENGTH = 1024
+const MAX_LENGTH = 1021
+
 const truncate = (str) => {
   if (typeof str === 'string' && str.length > OUTPUT_LENGTH) {
     return str.substring(0, MAX_LENGTH) + '...'

--- a/packages/winston-log-enricher/tests/unit/messageTruncate.tap.js
+++ b/packages/winston-log-enricher/tests/unit/messageTruncate.tap.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const tap = require('tap')
-const trucate = require('../../lib/truncate')
+const truncate = require('../../lib/truncate')
 
 tap.test('Should truncate string > 1024 chars', (t) => {
   const longString =
@@ -29,7 +29,7 @@ tap.test('Should truncate string > 1024 chars', (t) => {
     '1111111111111111111111111111111111111111111111111111111111111111' +
     '1111111111111111111111111111111111111111111111111111111111111111'
 
-  const processedStr = trucate(longString)
+  const processedStr = truncate(longString)
 
   t.equal(processedStr.length, 1024)
   t.equal(processedStr.substring(processedStr.length - 3), '...')
@@ -40,8 +40,22 @@ tap.test('Should truncate string > 1024 chars', (t) => {
 tap.test('Should return non-truncated string when <= 1024 chars', (t) => {
   const str = 'kenny loggins'
 
-  const processedStr = trucate(str)
+  const processedStr = truncate(str)
 
   t.equal(processedStr, str)
   t.end()
+})
+;[
+  { value: '', type: 'empty string' },
+  { value: undefined, type: 'undefined' },
+  { value: null, type: 'null' },
+  { value: {}, type: 'object' },
+  { value: [], type: 'array' },
+  { value: function () {}, type: 'function' }
+].forEach(({ value, type }) => {
+  tap.test(`should not truncate ${type}`, (t) => {
+    const newValue = truncate(value)
+    t.same(value, newValue)
+    t.end()
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed an issue where logging non-standard error objects under the `err` key causes APM to throw.

## Links
Fixes #86 

## Details
This fixes the reported issue.