### PR TITLE
chore: updating README to denote this package is no longer being maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+_**This is repository is no longer maintained. This functionality is in the New Relic Node.js agent as of [8.16.0](https://github.com/newrelic/node-newrelic/releases/tag/v8.16.0). Follow our [docs](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-nodejs/)**_
+
 <a href="https://opensource.newrelic.com/oss-category/#community-plus"><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/dark/Community_Plus.png"><source media="(prefers-color-scheme: light)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png"><img alt="New Relic Open Source community plus project banner." src="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png"></picture></a>
 
 # New Relic Node.js logging extensions


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Details
As you can see in PR this functionality was folded into agent.  The functionality in these legacy log enrichers has diverged as well and not for the better.  If customers want winston and pino log support they can upgrade to 8.1.60+ of agent.
